### PR TITLE
Feature/9 deploy document to GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub Pages
+# https://docusaurus.io/docs/deployment#deploying-to-github-pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: ./project-document
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
+
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: ./project-document/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm run build
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./project-document/build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,28 @@
+name: Test deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: ./project-document
+
+jobs:
+  test-deploy:
+    name: Test deployment to make sure it can be built
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: ./project-document/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Test build website
+        run: npm run build

--- a/project-document/docusaurus.config.js
+++ b/project-document/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://genesis-tech-tribe.github.io', // TODO: after deciding where the host location is, write it.
+  url: 'https://genesis-tech-tribe.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/nishiki-document',

--- a/project-document/docusaurus.config.js
+++ b/project-document/docusaurus.config.js
@@ -11,15 +11,17 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-test-site.com', // TODO: after deciding where the host location is, write it.
+  url: 'https://genesis-tech-tribe.github.io', // TODO: after deciding where the host location is, write it.
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/nishiki-document',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'genesis-tech-tribe', // Usually your GitHub org/user name.
-  projectName: 'Nishiki', // Usually your repo name.
+  projectName: 'nishiki-document', // Usually your repo name.
+  deploymentBranch: 'gh-pages', // The branch of your docs repo that you are publishing to GitHub pages.
+  trailingSlash : false,
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
## Overview
add two github actions. The goals are as following.

- deploy.yml: build docusaurus and push built contents to the gh-pages branch, which is the source of the GitHub Page.
- test-deploy.yml: verify if pull requested files can be built.

## Review points
These can work after merging into the main branch. So if there is a problem, I'll make issues to fix it.

I made a test in the api-doc-duplicate-test repo.
https://github.com/genesis-tech-tribe/api-doc-duplicate-test/actions/workflows/deploy.yml
https://genesis-tech-tribe.github.io/api-doc-duplicate-test/