### PR TITLE
18 create GitHub actions for deploying the open api document

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,6 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
-
       - uses: actions/checkout@v3
       - name: Build documents
         run: docker compose up

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: write
 
-defaults:
-  run:
-    working-directory: ./project-document
-
 jobs:
   deploy:
     name: Deploy to GitHub Pages
@@ -26,16 +22,8 @@ jobs:
           private_key: ${{ secrets.APP_SECRET }}
 
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-          cache-dependency-path: ./project-document/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-      - name: Build website
-        run: npm run build
+      - name: Build documents
+        run: docker compose up
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
@@ -44,7 +32,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./project-document/build
+          publish_dir: ./build
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+
+build
+!build/index.html

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # documents
+
+## Documents
+
+[Project Document](https://genesis-tech-tribe.github.io/nishiki-documents/project-document/index.html)
+[Web API Document](https://genesis-tech-tribe.github.io/nishiki-documents/web-api/index.html)

--- a/build/index.html
+++ b/build/index.html
@@ -1,0 +1,7 @@
+<html>
+	<head>
+		<script>
+			window.location.href = "./project-document/index.html";
+		</script>
+	</head>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  project-doc:
+    image: node:18
+    command: bash -c "npm ci && npm run build && cp -a /code/build/. /build/"
+    volumes:
+      - "./project-document:/code"
+      - "./build/project-document:/build"
+    working_dir: "/code"
+  web-api-doc:
+    image: node:18
+    volumes:
+      - "./web-api:/code"
+      - "./build/web-api:/build"
+    command: "npx @redocly/cli build-docs ./nishiki-web-api.yaml -o /build/index.html"
+    working_dir: "/code"

--- a/project-document/docusaurus.config.js
+++ b/project-document/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
   url: 'https://genesis-tech-tribe.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/nishiki-documents',
+  baseUrl: '/nishiki-documents/project-document',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## Overview

To deploy the web API document, changed how to build it and the structure of the documents.

## Changed

* Changed how to build to the docker-compose.
* Added a web API document.
* Added an index.html that redirects to the project document on the root of GitHub Pages.
