### PR TITLE
added a list of users in the group API

### DIFF
--- a/web-api/nishiki-web-api.yaml
+++ b/web-api/nishiki-web-api.yaml
@@ -347,7 +347,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsersBelongToGroup"
+                type: object
+                properties:
+                  users:
+                    $ref: "#/components/schemas/UsersBelongToGroup"
   /groups/{groupId}/users/{userId}:
     put:
       tags:
@@ -446,17 +449,19 @@ components:
           items:
             type: string
     UsersBelongToGroup:
-      type: object
-      properties:
-        userId:
-          type: string
-          nullable: false
-          format: uuid
-          example: 55b270e3-1fa7-4c89-b5b8-66ab0cac3626
-        userName:
-          type: string
-          nullable: false
-          example: hoge
+      type: array
+      items:
+        type: object
+        properties:
+          userId:
+            type: string
+            nullable: false
+            format: uuid
+            example: 55b270e3-1fa7-4c89-b5b8-66ab0cac3626
+          userName:
+            type: string
+            nullable: false
+            example: hoge
     Food:
       type: object
       properties:

--- a/web-api/nishiki-web-api.yaml
+++ b/web-api/nishiki-web-api.yaml
@@ -372,10 +372,12 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  users:
-                    $ref: "#/components/schemas/UsersBelongToGroup"
+                type: array
+                items:
+                  type: object
+                  properties:
+                    users:
+                      $ref: "#/components/schemas/User"
   /groups/{groupId}/users/{userId}:
     put:
       tags:
@@ -425,18 +427,12 @@ components:
         id:
           type: string
           nullable: false
-          example: 1234567890
+          format: uuid
+          example: 679adc58-b03a-4fb6-993b-c72404087375
         name:
           type: string
           nullable: false
           example: John
-        groups:
-          type: array
-          nullable: false
-          example:
-            - groupId
-          items:
-            type: string
     Container:
       type: object
       properties:
@@ -469,20 +465,6 @@ components:
           type: string
           nullable: false
           example: group1
-    UsersBelongToGroup:
-      type: array
-      items:
-        type: object
-        properties:
-          userId:
-            type: string
-            nullable: false
-            format: uuid
-            example: 55b270e3-1fa7-4c89-b5b8-66ab0cac3626
-          userName:
-            type: string
-            nullable: false
-            example: hoge
     Food:
       type: object
       properties:

--- a/web-api/nishiki-web-api.yaml
+++ b/web-api/nishiki-web-api.yaml
@@ -330,6 +330,24 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Container"
+  /groups/{groupId}/users:
+    get:
+      description: Get a list of users in the group
+      tags:
+        - group
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: list of users
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersBelongToGroup"
   /groups/{groupId}/users/{userId}:
     put:
       tags:
@@ -427,6 +445,18 @@ components:
             - 3434
           items:
             type: string
+    UsersBelongToGroup:
+      type: object
+      properties:
+        userId:
+          type: string
+          nullable: false
+          format: uuid
+          example: 55b270e3-1fa7-4c89-b5b8-66ab0cac3626
+        userName:
+          type: string
+          nullable: false
+          example: hoge
     Food:
       type: object
       properties:


### PR DESCRIPTION
## Overview of implementation

Added a list of users in the group API
#61 

## Review point

I added a new schema  `UsersBelongToGroup` referring to [the issue](https://github.com/genesis-tech-tribe/nishiki-documents/issues/61#issue-2022710695).
However, there is already a `User` schema. Should I use it as a return value instead of the new one?