### PR TITLE
fix /groups/?joinToGroup

### DIFF
--- a/web-api/nishiki-web-api.yaml
+++ b/web-api/nishiki-web-api.yaml
@@ -466,7 +466,6 @@ paths:
                   groupId:
                     type: string
                     example: d4825cf5-0b1b-dce3-1aa1-ed9adfd6b0bd
-  /groups/?Action=joinToGroup:
     put:
       summary: Join to a group
       description: Join to a group using the invitation link hash.


### PR DESCRIPTION
## Overview
move the put key of `/groups/?joinToGroup` path directive to inside of `/groups` path directive